### PR TITLE
bugfix: remove result_queue from esp_hass_call_service_config_t

### DIFF
--- a/examples/hello_world/main/main.c
+++ b/examples/hello_world/main/main.c
@@ -278,7 +278,6 @@ app_main(void)
 	call_service_config.service = service;
 	call_service_config.entity_id = entity_id;
 	call_service_config.delay = portMAX_DELAY;
-	call_service_config.result_queue = result_queue;
 
 	err = esp_hass_call_service(client, &call_service_config);
 	if (err != ESP_OK) {

--- a/include/esp_hass.h
+++ b/include/esp_hass.h
@@ -139,11 +139,10 @@ typedef struct {
  * are not supported yet.
  */
 typedef struct {
-	char *domain;		    /*!< domain name */
-	char *service;		    /*!< service name */
-	char *entity_id;	    /*!< entity_id */
-	TickType_t delay;	    /*!< timeout for receiving the result */
-	QueueHandle_t result_queue; /*!< result queue */
+	char *domain;	  /*!< domain name */
+	char *service;	  /*!< service name */
+	char *entity_id;  /*!< entity_id */
+	TickType_t delay; /*!< timeout for receiving the result */
 } esp_hass_call_service_config_t;
 
 /**
@@ -152,7 +151,7 @@ typedef struct {
 #define ESP_HASS_CALL_SERVICE_CONFIG_DEFAULT()                      \
 	{                                                           \
 		.domain = NULL, .service = NULL, .entity_id = NULL, \
-		.delay = portMAX_DELAY, .result_queue = NULL,       \
+		.delay = portMAX_DELAY,                             \
 	}
 
 /**

--- a/src/esp_hass.c
+++ b/src/esp_hass.c
@@ -863,7 +863,7 @@ esp_hass_call_service(esp_hass_client_handle_t client,
 		    esp_err_to_name(err));
 		goto fail;
 	}
-	if (xQueueReceive(config->result_queue, &msg, config->delay) !=
+	if (xQueueReceive(client->result_queue, &msg, config->delay) !=
 	    pdTRUE) {
 		ESP_LOGE(TAG, "failed to receive result: timeout");
 		err = ESP_FAIL;


### PR DESCRIPTION
esp_hass_call_service_config_t does not need result_queue because client
keeps it.